### PR TITLE
Add support for python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,19 @@ from setuptools import setup, find_packages
 import subprocess
 import sys
 
+if sys.version_info >= (3, 0):
+    try:
+        from distutils.command.build_py import build_py_2to3 as build_py
+        from distutils.command.build_scripts import build_scripts_2to3 as build_scripts
+    except ImportError:
+        raise ImportError("build_py_2to3 not found in distutils - it is required for Python 3.x")
+    suffix = "-py3k"
+else:
+    from distutils.command.build_py import build_py
+    from distutils.command.build_scripts import build_scripts
+    suffix = ""
+
+
 import os
 mydir = os.path.dirname(__file__)
 
@@ -26,7 +39,7 @@ with open('README.rst') as f:
     long_description = f.read()
 
 setup(
-    name="ftd2xx",
+    name="ftd2xx" + suffix,
     version=version,
     packages=find_packages(),
     # metadata for upload to PyPI
@@ -39,5 +52,6 @@ setup(
     zip_safe=False,
     test_suite="ftd2xx.tests.t_ftd2xx",
     long_description=long_description,
+    cmdclass = {'build_py': build_py, 'build_scripts': build_scripts},
     # could also include long_description, download_url, classifiers, etc.
 )


### PR DESCRIPTION
The python tool 2to3.py seems to do a very good job of converting ftd2xx to work with python 3.2, so I've integrated it into the setup.py script.

Tested using python 3.2 and distribute 0.6.27.
