### PR TITLE
Remove call to createDeviceInfoList.

### DIFF
--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -81,7 +81,6 @@ def getDeviceInfoDetail(devnum=0):
     h = _ft.FT_HANDLE()
     n = c.c_buffer(MAX_DESCRIPTION_SIZE)
     d = c.c_buffer(MAX_DESCRIPTION_SIZE)
-    createDeviceInfoList()
     call_ft(_ft.FT_GetDeviceInfoDetail, _ft.DWORD(devnum),
             c.byref(f), c.byref(t), c.byref(i), c.byref(l), n, d, c.byref(h))
     return {'index': devnum, 'flags': f.value, 'type': t.value,
@@ -134,7 +133,6 @@ class FTD2XX(object):
         and populate the device info in the instance dictionary."""
         self.handle = handle
         self.status = 1
-        createDeviceInfoList()
         self.__dict__.update(self.getDeviceInfo())
 
     def close(self):


### PR DESCRIPTION
"This function takes quite a while to run and can cause major slowdown. The d2xx developer documentation explicitly states that functions which rely on the device info list can be called, createDeviceInfoList must be called. A developer following that guide (such as myself) would be thrown off by all the implicit calls to that function."