### PR TITLE
Windows x64 DLL when automatically installed has generic name.

### DIFF
--- a/ftd2xx/_ftd2xx.py
+++ b/ftd2xx/_ftd2xx.py
@@ -35,7 +35,10 @@ _libraries = {}
 
 if sys.platform == 'win32':
     if sys.maxsize > 2**32: # 64-bit
-        _libraries['ftd2xx.dll'] = WinDLL('ftd2xx64.dll')
+        try:
+            _libraries['ftd2xx.dll'] = WinDLL('ftd2xx64.dll')
+        except:
+            _libraries['ftd2xx.dll'] = WinDLL('ftd2xx.dll')
     else: # 32-bit
         _libraries['ftd2xx.dll'] = WinDLL('ftd2xx.dll')
 else:

--- a/ftd2xx/_ftd2xx.py
+++ b/ftd2xx/_ftd2xx.py
@@ -34,12 +34,9 @@ else:
 _libraries = {}
 
 if sys.platform == 'win32':
-    if sys.maxsize > 2**32: # 64-bit
-        try:
-            _libraries['ftd2xx.dll'] = WinDLL('ftd2xx64.dll')
-        except:
-            _libraries['ftd2xx.dll'] = WinDLL('ftd2xx.dll')
-    else: # 32-bit
+    if sys.maxsize > 2**32 and util.find_library('ftd2xx64'): # 64-bit
+        _libraries['ftd2xx.dll'] = WinDLL('ftd2xx64.dll')
+    else: # 32-bit, or 64-bit library with plain name
         _libraries['ftd2xx.dll'] = WinDLL('ftd2xx.dll')
 else:
     _libraries['ftd2xx.dll'] = CDLL('libftd2xx.so')


### PR DESCRIPTION
Using the FTDI installer results in the 64bit library being installed with the name 'ftd2xx.dll' instead of 'ftd2xx64.dll'.   This is a simple hack to allow for both possibilities.