### PR TITLE
Updated FTD2XX.setBitMode type hint (fixes #61)

### DIFF
--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -452,7 +452,7 @@ class FTD2XX(AbstractContextManager):
         call_ft(_ft.FT_GetLatencyTimer, self.handle, c.byref(latency))
         return latency.value
 
-    def setBitMode(self, mask: int, enable: bool):
+    def setBitMode(self, mask: int, enable: int):
         call_ft(_ft.FT_SetBitMode, self.handle, _ft.UCHAR(mask), _ft.UCHAR(enable))
 
     def getBitMode(self) -> int:


### PR DESCRIPTION
Changed typing hint for parameter enable of FTD2XX.setBitMode from bool to int. This is to accomodate settings other than 0 and 1, which is needed for MPSSE and other modes.

Passes pytest tests and has been used successfully with an FT4232 in MPSSE mode where the enable parameter is set to 0x2.

Fixes #61, see issue for further information.