### PR TITLE
Fix eeRead strings

### DIFF
--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -554,10 +554,10 @@ class FTD2XX(AbstractContextManager):
                 Signature1=0,
                 Signature2=0xFFFFFFFF,
                 Version=2,
-                Manufacturer=c.addressof(Manufacturer),
-                ManufacturerId=c.addressof(ManufacturerId),
-                Description=c.addressof(Description),
-                SerialNumber=c.addressof(SerialNumber),
+                Manufacturer=c.cast(Manufacturer, c.c_char_p),
+                ManufacturerId=c.cast(ManufacturerId, c.c_char_p),
+                Description=c.cast(Description, c.c_char_p),
+                SerialNumber=c.cast(SerialNumber, c.c_char_p),
             )
         )
 


### PR DESCRIPTION
The `eeRead()` method in ftd2xx.py may return a `ft_program_data` that contains addresses pointing to objects already being freed.

The fix is provided by Michael Schlagmueller in [1], which replaces `addressof()` with `cast()` to properly retain the object reference count, as described in [2].

[1] https://github.com/snmishra/ftd2xx/issues/64#issuecomment-1505812213,
[2] https://docs.python.org/3/library/ctypes.html#ctypes.cast.